### PR TITLE
Fix: Rename "address" property to "email" in IMCContact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,34 @@
       "dependencies": {
         "@cloudflare/workers-types": "^4.20230419.0",
         "itty-router": "^4.0.27",
+        "mimetext": "^3.0.24",
         "prettier": "^3.2.5",
         "typescript": "^5.0.4",
         "wrangler": "^3.0.0",
         "zod-validation-error": "^3.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
+      "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.25.6.tgz",
+      "integrity": "sha512-Gz0Nrobx8szge6kQQ5Z5MX9L3ObqNwCQY1PSwSNzreFL7aHGxv8Fp2j3ETV6/wWdbiV+mW6OSm8oQhg3Tcsniw==",
+      "dependencies": {
+        "core-js-pure": "^3.30.2",
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -564,11 +588,11 @@
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -615,6 +639,16 @@
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/core-js-pure": {
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
+      "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/data-uri-to-buffer": {
@@ -702,9 +736,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -823,6 +857,11 @@
       "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-4.0.27.tgz",
       "integrity": "sha512-Q3/GOE2EJvyu3hhxGN3WDWh3QNg4v7h1KFx/jSLcIOOkpSI1jUFTgGefEESXon4j5YwqCIf0DEemjiVAFSBiUw=="
     },
+    "node_modules/js-base64": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
+    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -840,6 +879,40 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimetext": {
+      "version": "3.0.24",
+      "resolved": "https://registry.npmjs.org/mimetext/-/mimetext-3.0.24.tgz",
+      "integrity": "sha512-UdG1KVfcxeEfo6el91lzFG2WLLTm8DxSK/rosxx5H2Pjla50+DSsjTgr9BRAfAkbQWaxvzcaTO+bHK5ZrdKdfA==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@babel/runtime-corejs3": "^7.15.4",
+        "js-base64": "^3.7.5",
+        "mime-types": "^2.1.35"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://patreon.com/muratgozel"
       }
     },
     "node_modules/miniflare": {
@@ -919,9 +992,9 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -963,6 +1036,11 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -1099,9 +1177,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
-      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -1165,9 +1243,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
   },
   "dependencies": {
     "@cloudflare/workers-types": "^4.20230419.0",
+    "itty-router": "^4.0.27",
+    "mimetext": "^3.0.24",
+    "prettier": "^3.2.5",
     "typescript": "^5.0.4",
     "wrangler": "^3.0.0",
-    "prettier": "^3.2.5",
-    "itty-router": "^4.0.27",
     "zod-validation-error": "^3.0.0"
   }
 }

--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -129,7 +129,7 @@ class Email {
 	 */
 	protected static convertContact(contact: IContact): IMCContact {
 		if (typeof contact === 'string') {
-			return { address: contact, name: undefined };
+			return { email: contact, name: undefined };
 		}
 
 		return { email: contact.address, name: contact.name };

--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -1,6 +1,6 @@
 import { IContact, IEmail } from '../schema/email';
 
-type IMCPersonalization = { to: IMCContact[], dkim_domain: string | undefined, dkim_selector: string | undefined, dkim_private_key: string | undefined};
+type IMCPersonalization = { to: IMCContact[], dkim_domain: string | undefined, dkim_selector: string | undefined, dkim_private_key: string | undefined };
 type IMCContact = { email: string; name: string | undefined };
 type IMCContent = { type: string; value: string };
 
@@ -51,9 +51,9 @@ class Email {
 		// Convert 'to' field
 		const toContacts: IMCContact[] = Email.convertContacts(email.to);
 		if (env.DKIM_DOMAIN && env.DKIM_SELECTOR && env.DKIM_PRIVATE_KEY) {
-			personalizations.push({ to: toContacts, dkim_domain: env.DKIM_DOMAIN, dkim_selector: env.DKIM_SELECTOR, dkim_private_key: env.DKIM_PRIVATE_KEY});
+			personalizations.push({ to: toContacts, dkim_domain: env.DKIM_DOMAIN, dkim_selector: env.DKIM_SELECTOR, dkim_private_key: env.DKIM_PRIVATE_KEY });
 		} else {
-			personalizations.push({to: toContacts});
+			personalizations.push({ to: toContacts, dkim_domain: undefined, dkim_selector: undefined, dkim_private_key: undefined });
 		}
 
 		let replyTo: IMCContact | undefined = undefined;

--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -1,126 +1,139 @@
 import { IContact, IEmail } from '../schema/email';
+import { EmailMessage } from "cloudflare:email";
+import { createMimeMessage, MailboxType, ContentOptions, MIMEMessage } from "mimetext";
 
-type IMCPersonalization = { to: IMCContact[], dkim_domain: string | undefined, dkim_selector: string | undefined, dkim_private_key: string | undefined };
-type IMCContact = { email: string; name: string | undefined };
-type IMCContent = { type: string; value: string };
+type IMCContact = { addr: string; name?: string; type?: MailboxType };
 
-interface IMCEmail {
-	personalizations: IMCPersonalization[];
-	from: IMCContact;
-	reply_to: IMCContact | undefined;
-	cc: IMCContact[] | undefined;
-	bcc: IMCContact[] | undefined;
-	subject: string;
-	content: IMCContent[];
-}
 
 class Email {
 	/**
-	 *
-	 * @param email
+	 * Sends an email via the Cloudflare Email service.
+	 * @param email The email to send, conforming to the IEmail interface.
+	 * @param env The environment variables, containing the SEB worker.
+	 * @returns A promise that resolves when the email is sent.
 	 */
-	static async send(email: IEmail, env: Env) {
-		// convert email to IMCEmail (MailChannels Email)
-		const mcEmail: IMCEmail = Email.convertEmail(email, env);
+	static async send(email: IEmail, env: Env): Promise<void> {
+		const msg: MIMEMessage = Email.convertEmail(email);
 
-		// send email through MailChannels
-		const resp = await fetch(
-			new Request('https://api.mailchannels.net/tx/v1/send', {
-				method: 'POST',
-				headers: {
-					'content-type': 'application/json',
-				},
-				body: JSON.stringify(mcEmail),
-			})
-		);
-
-		// check if email was sent successfully
-		if (resp.status > 299 || resp.status < 200) {
-			throw new Error(`Error sending email: ${resp.status} ${resp.statusText} ${await resp.text()} - ${JSON.stringify(mcEmail)}`);
+		let fromAddress: string;
+		if (typeof email.from === 'string') {
+			fromAddress = email.from;
+		} else {
+			fromAddress = email.from.address;
 		}
+
+		let toAddresses: string;
+		toAddresses = email.to;
+
+		var message = new EmailMessage(
+			fromAddress,
+			toAddresses,
+			msg.asRaw(),
+		)
+		try {
+			await env.SEB.send(message)
+		} catch (e) {
+			throw new Error(`Error sending email: ${e.message}`);
+		}
+
 	}
+
 
 	/**
 	 * Converts an IEmail to an IMCEmail
 	 * @param email
 	 * @protected
 	 */
-	protected static convertEmail(email: IEmail, env: Env): IMCEmail {
-		const personalizations: IMCPersonalization[] = [];
-
-		// Convert 'to' field
-		const toContacts: IMCContact[] = Email.convertContacts(email.to);
-		if (env.DKIM_DOMAIN && env.DKIM_SELECTOR && env.DKIM_PRIVATE_KEY) {
-			personalizations.push({ to: toContacts, dkim_domain: env.DKIM_DOMAIN, dkim_selector: env.DKIM_SELECTOR, dkim_private_key: env.DKIM_PRIVATE_KEY });
-		} else {
-			personalizations.push({ to: toContacts, dkim_domain: undefined, dkim_selector: undefined, dkim_private_key: undefined });
-		}
-
-		let replyTo: IMCContact | undefined = undefined;
-		let bccContacts: IMCContact[] | undefined = undefined;
-		let ccContacts: IMCContact[] | undefined = undefined;
-
-		// Convert 'replyTo' field
-		if (email.replyTo) {
-			const replyToContacts: IMCContact[] = Email.convertContacts(email.replyTo);
-			replyTo = replyToContacts.length > 0 ? replyToContacts[0] : { email: '', name: undefined };
-		}
-
-		// Convert 'cc' field
-		if (email.cc) {
-			ccContacts = Email.convertContacts(email.cc);
-		}
-
-		// Convert 'bcc' field
-		if (email.bcc) {
-			bccContacts = Email.convertContacts(email.bcc);
+	protected static convertEmail(email: IEmail): MIMEMessage {
+		if (!email) {
+			throw new Error("Email is null or undefined");
 		}
 
 		const from: IMCContact = Email.convertContact(email.from);
+		if (!from) {
+			throw new Error("Email.from is null or undefined");
+		}
 
-		// Convert 'subject' field
+		const toContacts: IMCContact[] = Email.convertContacts(email.to, 'To');
+		if (!toContacts || toContacts.length === 0) {
+			throw new Error("Email.to is null, undefined, or empty");
+		}
+
 		const subject: string = email.subject;
+		if (!subject) {
+			throw new Error("Email.subject is null or undefined");
+		}
+
+		const msg = createMimeMessage();
+		msg.setSender(from);
+		msg.setTo(toContacts);
+		msg.setSubject(subject);
+
+		let Recipients: IMCContact[] = [];
+		Recipients = Recipients.concat(toContacts);
+
+
+		// Convert 'cc' field
+		let ccContacts: IMCContact[] = [];
+		if (email.cc) {
+			ccContacts = Email.convertContacts(email.cc, 'Cc');
+			if (ccContacts && ccContacts.length > 0) {
+				Recipients = Recipients.concat(ccContacts);
+			}
+		}
+
+		let bccContacts: IMCContact[] = [];
+		// Convert 'bcc' field
+		if (email.bcc) {
+			bccContacts = Email.convertContacts(email.bcc, 'Bcc');
+			if (bccContacts && bccContacts.length > 0) {
+				Recipients = Recipients.concat(bccContacts);
+			}
+		}
 
 		// Convert 'text' field
-		const textContent: IMCContent[] = [];
+
 		if (email.text) {
-			textContent.push({ type: 'text/plain', value: email.text });
+			const textContent: ContentOptions = { contentType: 'text/plain', data: email.text }
+			msg.addMessage(textContent);
 		}
 
 		// Convert 'html' field
-		const htmlContent: IMCContent[] = [];
+
 		if (email.html) {
-			htmlContent.push({ type: 'text/html', value: email.html });
+			const htmlContent: ContentOptions = { contentType: 'text/html', data: email.html }
+			msg.addMessage(htmlContent);
 		}
 
-		const content: IMCContent[] = [...textContent, ...htmlContent];
-
-		return {
-			personalizations,
-			from,
-			cc: ccContacts,
-			bcc: bccContacts,
-			reply_to: replyTo,
-			subject,
-			content,
-		};
+		return msg
 	}
-
 	/**
 	 * Converts an IContact or IContact[] to a Contact[]
 	 * @param contacts
+	 * @param type - An optional parameter of type MailboxType
 	 * @protected
 	 */
-	protected static convertContacts(contacts: IContact | IContact[]): IMCContact[] {
+	protected static convertContacts(contacts: IContact | IContact[], type?: MailboxType): IMCContact[] {
 		if (!contacts) {
 			return [];
 		}
 
 		const contactArray: IContact[] = Array.isArray(contacts) ? contacts : [contacts];
-		const convertedContacts: IMCContact[] = contactArray.map(Email.convertContact);
+
+		const convertedContacts: IMCContact[] = contactArray.map(contact => {
+			const convertedContact = Email.convertContact(contact);
+
+			// 如果 type 存在，附加到 convertedContact 中
+			if (type) {
+				convertedContact.type = type; // 假设 IMCContact 中有一个 type 属性
+			}
+
+			return convertedContact;
+		});
 
 		return convertedContacts;
 	}
+
 
 	/**
 	 * Converts an IContact to a Contact
@@ -128,11 +141,9 @@ class Email {
 	 * @protected
 	 */
 	protected static convertContact(contact: IContact): IMCContact {
-		if (typeof contact === 'string') {
-			return { email: contact, name: undefined };
-		}
-
-		return { email: contact.address, name: contact.name };
+		return typeof contact === 'string'
+			? { addr: contact }
+			: { addr: contact.address, name: contact.name };
 	}
 }
 

--- a/src/schema/email.ts
+++ b/src/schema/email.ts
@@ -9,7 +9,7 @@ const iContactSchema = z.union([
 ]);
 
 const iEmailSchema = z.object({
-	to: z.union([iContactSchema, z.array(iContactSchema)]),
+	to: z.string(),
 	replyTo: z.union([iContactSchema, z.array(iContactSchema)]).optional(),
 	cc: z.union([iContactSchema, z.array(iContactSchema)]).optional(),
 	bcc: z.union([iContactSchema, z.array(iContactSchema)]).optional(),

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,11 @@
-name = "worker-email"
+name = "worker-email-production"
 main = "src/main.ts"
-compatibility_date = "2023-09-02"
-
+compatibility_date = "2024-09-23"
+send_email = [
+    {type = "send_email", name = "SEB"},
+]
+compatibility_flags = ["nodejs_compat"]
 [build]
 command = "npm install"
+[observability]
+enabled = true


### PR DESCRIPTION
Renamed the "address" property to "email" in the IMCContact interface to match the actual property name in the contact object.